### PR TITLE
Add AIML API provider

### DIFF
--- a/examples/provider_specific/aimlapi/run_agent.py
+++ b/examples/provider_specific/aimlapi/run_agent.py
@@ -1,0 +1,26 @@
+import os
+from pathlib import Path
+
+from pydantic_ai.models.openai import OpenAIModel
+
+import marvin
+from marvin.providers.aimlapi import AIMLAPIProvider
+
+
+def write_file(path: str, content: str) -> None:
+    """Write content to a file."""
+    Path(path).write_text(content)
+
+
+writer = marvin.Agent(
+    model=OpenAIModel(
+        "gpt-4o-mini",
+        provider=AIMLAPIProvider(api_key=os.getenv("AIML_API_KEY")),
+    ),
+    name="AI/ML Writer",
+    instructions="Write concise, engaging content for developers",
+    tools=[write_file],
+)
+
+result = marvin.run("how to use pydantic? write haiku to docs.md", agents=[writer])
+print(result)

--- a/src/marvin/providers/__init__.py
+++ b/src/marvin/providers/__init__.py
@@ -1,0 +1,3 @@
+from .aimlapi import AIMLAPIProvider
+
+__all__ = ["AIMLAPIProvider"]

--- a/src/marvin/providers/aimlapi.py
+++ b/src/marvin/providers/aimlapi.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import os
+from typing import overload
+
+from httpx import AsyncClient as AsyncHTTPClient
+from openai import AsyncOpenAI
+
+from pydantic_ai.exceptions import UserError
+from pydantic_ai.models import cached_async_http_client
+from pydantic_ai.profiles import ModelProfile
+from pydantic_ai.profiles.openai import openai_model_profile
+from pydantic_ai.providers import Provider
+
+
+class AIMLAPIProvider(Provider[AsyncOpenAI]):
+    """Provider for the AI/ML API."""
+
+    @property
+    def name(self) -> str:  # pragma: no cover - simple property
+        return "aimlapi"
+
+    @property
+    def base_url(self) -> str:  # pragma: no cover - simple property
+        return "https://api.aimlapi.com/v1"
+
+    @property
+    def client(self) -> AsyncOpenAI:
+        return self._client
+
+    def model_profile(self, model_name: str) -> ModelProfile | None:  # pragma: no cover - thin wrapper
+        return openai_model_profile(model_name)
+
+    @overload
+    def __init__(self) -> None: ...
+
+    @overload
+    def __init__(self, *, api_key: str) -> None: ...
+
+    @overload
+    def __init__(self, *, api_key: str, http_client: AsyncHTTPClient) -> None: ...
+
+    @overload
+    def __init__(self, *, openai_client: AsyncOpenAI | None = None) -> None: ...
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        openai_client: AsyncOpenAI | None = None,
+        http_client: AsyncHTTPClient | None = None,
+    ) -> None:
+        api_key = api_key or os.getenv("AIML_API_KEY")
+        if not api_key and openai_client is None:
+            raise UserError(
+                "Set the `AIML_API_KEY` environment variable or pass it via `AIMLAPIProvider(api_key=...)` "
+                "to use the AI/ML API provider."
+            )
+
+        if openai_client is not None:
+            self._client = openai_client
+        elif http_client is not None:
+            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
+        else:
+            http_client = cached_async_http_client(provider="aimlapi")
+            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)


### PR DESCRIPTION
## Summary
- add AIML API provider for OpenAI-compatible models
- example agent using AIML API provider

## Testing
- `uv run pre-commit run --files src/marvin/providers/__init__.py src/marvin/providers/aimlapi.py examples/provider_specific/aimlapi/run_agent.py` *(fail: unable to access 'https://github.com/astral-sh/ruff-pre-commit/')*
- `uv run pytest` *(fail: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68a8303f80708329a1d69baaba16e97e